### PR TITLE
Using Object.defineProperty since __defineGetter__ is deprecated.

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -39,7 +39,7 @@ var define = function(name, generator) {
 	if (generator.length) {
 		this[name] = generator;
 	} else {
-		this.__defineGetter__(name, generator);
+		Object.defineProperty(this, name, { get: generator });
 	}
 
 	this['_' + name] = generator;


### PR DESCRIPTION
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineGetter
