### PR TITLE
Fix typo so that format string passed to casual.date is not just ignored

### DIFF
--- a/src/providers/date.js
+++ b/src/providers/date.js
@@ -15,7 +15,7 @@ var provider = {
 
 	date: function(format) {
 		format = format || 'YYYY-MM-DD';
-		return this.moment.format(this.format);
+		return this.moment.format(format);
 	},
 
 	time: function(format) {


### PR DESCRIPTION
The format string passed to casual.date was getting ignored due to a typo. 
