### PR TITLE
Allow the user to specify ZIP or ZIP+4

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,18 @@ Casual uses javascript properties for common generators so you don't need to use
 
 // Address
 
-casual.country             // 'United Kingdom'
-casual.city                // 'New Ortiz chester'
-casual.zip(digits = [5,9]) // '26995-7979' (if no digits specified then random selection between ZIP and ZIP+4)
-casual.street              // 'Jadyn Islands'
-casual.address             // '6390 Tremblay Pines Suite 784'
-casual.address1            // '8417 Veda Circles'
-casual.address2            // 'Suite 648'
-casual.state               // 'Michigan'
-casual.state_abbr          // 'CO'
-casual.latitude            // 90.0610
-casual.longitude           // 180.0778
-casual.building_number     // 2413
+casual.country              // 'United Kingdom'
+casual.city                 // 'New Ortiz chester'
+casual.zip(digits = {5, 9}) // '26995-7979' (if no digits specified then random selection between ZIP and ZIP+4)
+casual.street               // 'Jadyn Islands'
+casual.address              // '6390 Tremblay Pines Suite 784'
+casual.address1             // '8417 Veda Circles'
+casual.address2             // 'Suite 648'
+casual.state                // 'Michigan'
+casual.state_abbr           // 'CO'
+casual.latitude             // 90.0610
+casual.longitude            // 180.0778
+casual.building_number      // 2413
 
 // Text
 

--- a/README.md
+++ b/README.md
@@ -39,18 +39,18 @@ Casual uses javascript properties for common generators so you don't need to use
 
 // Address
 
-casual.country          // 'United Kingdom'
-casual.city             // 'New Ortiz chester'
-casual.zip              // '26995'
-casual.street           // 'Jadyn Islands'
-casual.address          // '6390 Tremblay Pines Suite 784'
-casual.address1         // '8417 Veda Circles'
-casual.address2         // 'Suite 648'
-casual.state            // 'Michigan'
-casual.state_abbr       // 'CO'
-casual.latitude         // 90.0610
-casual.longitude        // 180.0778
-casual.building_number  // 2413
+casual.country             // 'United Kingdom'
+casual.city                // 'New Ortiz chester'
+casual.zip(digits = [5,9]) // '26995-7979' (if no digits specified then random selection between ZIP and ZIP+4)
+casual.street              // 'Jadyn Islands'
+casual.address             // '6390 Tremblay Pines Suite 784'
+casual.address1            // '8417 Veda Circles'
+casual.address2            // 'Suite 648'
+casual.state               // 'Michigan'
+casual.state_abbr          // 'CO'
+casual.latitude            // 90.0610
+casual.longitude           // 180.0778
+casual.building_number     // 2413
 
 // Text
 

--- a/src/providers/address.js
+++ b/src/providers/address.js
@@ -50,8 +50,14 @@ var provider = {
 		return this.populate_one_of(this.city_formats);
 	},
 
-	zip: function() {
-		return this.numerify(this.random_element(this.zip_formats));
+	zip: function(digits) {
+		if (digits === 5) {
+			return this.numerify(this.zip_formats[0]);
+		} else if (digits === 9) {
+			return this.numerify(this.zip_formats[1]);
+		} else {
+			return this.numerify(this.random_element(this.zip_formats));
+		}
 	},
 
 	street_suffix: function() {


### PR DESCRIPTION
Some forms don't allow entry of a ZIP+4 and must have a 5-digit ZIP to be valid.