### PR TITLE
Failing test for seeded unix_time generation

### DIFF
--- a/test/casual.js
+++ b/test/casual.js
@@ -279,32 +279,39 @@ describe('API', function() {
 
 	describe('Generator seeding', function() {
 		var create_data_set = function() {
-			return [
-				casual.description,
-				casual.text,
-				casual.random,
-				casual.integer,
-				casual.card_number,
-				casual.phone,
-				casual.unix_time,
-				casual.day_of_year,
-				casual.date,
-				casual.time
-			];
+			return {
+				description: casual.description,
+				text: casual.text,
+				random: casual.random,
+				integer: casual.integer,
+				card_number: casual.card_number,
+				phone: casual.phone,
+				unix_time: casual.unix_time,
+				day_of_year: casual.day_of_year,
+				date: casual.date,
+				time: casual.time,
+				moment_string: casual.moment.toISOString(),
+			};
 		};
 
-		it('Should repeat random sequence on same seed', function() {
+		it('Should repeat random sequence on same seed', function(done) {
+			this.timeout(3000);
+
 			var seed = 123;
 
 			casual.seed(seed);
 			var set1 = create_data_set();
 
-			casual.seed(seed);
-			var set2 = create_data_set();
+			setTimeout(function () {
+				casual.seed(seed);
+				var set2 = create_data_set();
 
-			for (var i in set1) {
-				set1[i].should.be.equal(set2[i]);
-			}
+				for (var i in set1) {
+					set1[i].should.be.equal(set2[i], i);
+				}
+
+				done();
+			}, 2001); // Check for date/time perturbation
 		})
 	});
 


### PR DESCRIPTION
`.unix_time` does not generate the same time when given the same seed twice. But it does _iff_ you generate the two times within a few seconds of each other.

In other words, `.unix_time` (and therefore `.moment` and anything else based off it) is not pure under the seed.

The root cause is that the maximum parameter to `.integer(0, moment().unix())` is the current time. This makes the generated sequence dependent on when the generator is called! Waiting a couple of seconds is enough to show the problem (two seconds should guarantee failure).
