### PR TITLE
allow redefining of custom generators

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,7 +37,10 @@ var define = function(name, generator) {
 	if (generator.length) {
 		this[name] = generator.bind(this);
 	} else {
-		Object.defineProperty(this, name, { get: generator });
+		Object.defineProperty(this, name, { 
+			get: generator,
+			configurable: true
+		});
 	}
 
 	this['_' + name] = generator.bind(this);


### PR DESCRIPTION
This pull request allows `custom generators` to be redefined. So effectively you can run 

```
casual.define('id', () => {});
casual.define('id', () => {});
``` 

Without this pull request an `Uncaught TypeError: Cannot redefine property: id(…)` will be thrown on the second line. Why is this required? Because `node processes` can be reused when running tests in parallel. So sometimes the process will parse a file twice, because it's cheaper to re-evaluate a single file, than to restart the entire process.

An example of this is when developing with [wallaby.js](wallabyjs.com). Wallaby will re-read  my own definitions while I edit them, but it will not reset the `casual` instance itself.