### PR TITLE
Build casual with selected providers

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -1,0 +1,25 @@
+var helpers = require('./helpers');
+
+var build = function(providers) {
+    var casual = helpers.extend({}, helpers);
+
+    casual.functions = function () {
+        var adapter = {};
+
+        Object.keys(this).forEach(function (name) {
+            if (name[0] === '_') {
+                adapter[name.slice(1)] = casual[name];
+            }
+        });
+
+        return adapter;
+    };
+
+    providers.forEach(function (provider) {
+        casual.register_provider(provider)
+    });
+
+    return casual;
+};
+
+module.exports = build;

--- a/src/casual.js
+++ b/src/casual.js
@@ -1,4 +1,5 @@
 var helpers = require('./helpers'),
+	build = require('./build'),
     exists = require('fs').existsSync;
 
 var safe_require = function(filename) {
@@ -8,63 +9,47 @@ var safe_require = function(filename) {
 	return {};
 };
 
-var build_casual = function() {
-	var casual = helpers.extend({}, helpers);
+var providers = [
+	'address',
+	'text',
+	'internet',
+	'person',
+	'number',
+	'date',
+	'payment',
+	'misc',
+	'color'
+];
 
-	casual.functions = function() {
-		var adapter = {};
+var casual = build([]);
 
-		Object.keys(this).forEach(function(name) {
-			if (name[0] === '_') {
-				adapter[name.slice(1)] = casual[name];
-			}
+casual.register_locale = function(locale) {
+	casual.define(locale, function() {
+		var casual = build([]);
+
+		providers.forEach(function(provider) {
+			casual.register_provider(helpers.extend(
+				require('./providers/' + provider),
+				safe_require(__dirname + '/providers/' + locale + '/' + provider)
+			));
 		});
 
-		return adapter;
-	};
-
-	var providers = [
-		'address',
-		'text',
-		'internet',
-		'person',
-		'number',
-		'date',
-		'payment',
-		'misc',
-		'color'
-	];
-
-	casual.register_locale = function(locale) {
-		casual.define(locale, function() {
-			var casual = build_casual();
-
-			providers.forEach(function(provider) {
-				casual.register_provider(helpers.extend(
-					require('./providers/' + provider),
-					safe_require(__dirname + '/providers/' + locale + '/' + provider)
-				));
-			});
-
-			return casual;
-		});
-	}
-
-	var locales = [
-		'en_US',
-		'ru_RU',
-		'uk_UA',
-		'nl_NL',
-		'en_CA',
-		'it_CH',
-		'de_DE',
-		'ar_SY'
-	];
-
-	locales.forEach(casual.register_locale);
-
-	return casual;
+		return casual;
+	});
 };
 
+var locales = [
+	'en_US',
+	'ru_RU',
+	'uk_UA',
+	'nl_NL',
+	'en_CA',
+	'it_CH',
+	'de_DE',
+	'ar_SY'
+];
+
+locales.forEach(casual.register_locale);
+
 // Default locale is en_US
-module.exports = build_casual().en_US;
+module.exports = casual.en_US;


### PR DESCRIPTION
I'm using `casual` to generate fake data on the client and the resulting js file is very big, partly because `casual` includes `moment`.

I made some changes which enable building custom casual objects using only providers that are actually needed by the application. This greatly reduces the amount of js to be downloaded if only a few providers are used.

```
var build = require('casual/src/build');
var number = require('casual/src/providers/number');
var person = require('casual/src/providers/person');
var address = require('casual/src/providers/address');

module.exports = build([number, person, address,]);
```

If you find this useful please publish a new npm package. This commit should not affect other users and all tests are passing.
