### PR TITLE
[Deps] Use ^ to allow deduping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
 language: node_js
 node_js:
+  - "7"
+  - "6"
+  - "5"
+  - "4"
+  - "iojs"
+  - "0.12"
+  - "0.10"
   - "0.8"
+sudo: false
+before_install:
+  - 'if [ "${TRAVIS_NODE_VERSION}" != "0.9" ]; then case "$(npm --version)" in 1.*) npm install -g npm@1.4.28 ;; 2.*) npm install -g npm@2 ;; esac ; fi'
+  - 'if [ "${TRAVIS_NODE_VERSION}" != "0.6" ] && [ "${TRAVIS_NODE_VERSION}" != "0.9" ]; then npm install -g npm; fi'

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "author": "Egor Gumenyuk <boo1ean0807@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "mersenne-twister": "~1.0.1",
-    "moment": "~2.11.1"
+    "mersenne-twister": "^1.0.1",
+    "moment": "^2.11.1"
   },
   "devDependencies": {
     "should": "~3.1.2",


### PR DESCRIPTION
There's no reason to use ~ ever when ^ exists. By using ^, you'll allow people to dedupe compatible versions of your deps.
