### PR TITLE
Add return-type annotation for seed declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -289,7 +289,7 @@ declare module "casual" {
     register_provider(provider: Object): void;
 
     // SEEDING
-    seed(n: number);
+    seed(n: number): any;
 
     // GENERATORS functions
     functions(): functions;


### PR DESCRIPTION
Compiling projects with no-implicit-any throws:

```
node_modules/casual/index.d.ts(292,5): error TS7010: 'seed', which lacks return-type annotation, implicitly has an 'any' return type.
```