### PR TITLE
Remove old node versions from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ node_js:
   - "6"
   - "5"
   - "4"
-  - "iojs"
-  - "0.12"
-  - "0.10"
-  - "0.8"
 sudo: false
 before_install:
-  - 'if [ "${TRAVIS_NODE_VERSION}" != "0.9" ]; then case "$(npm --version)" in 1.*) npm install -g npm@1.4.28 ;; 2.*) npm install -g npm@2 ;; esac ; fi'
-  - 'if [ "${TRAVIS_NODE_VERSION}" != "0.6" ] && [ "${TRAVIS_NODE_VERSION}" != "0.9" ]; then npm install -g npm; fi'
+  - 'npm install -g npm'


### PR DESCRIPTION
Npm no longer supports node versions <4, since they are officially eol.
https://docs.npmjs.com/troubleshooting/try-the-latest-stable-version-of-node