### PR TITLE
Fix typescript declaration incorrect

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
-declare module "casual" {
-  
-  interface generators {
+declare namespace Casual {
+  interface Generators {
     // EMBEDDED GENERATORS
     _country(): string;         // 'United Kingdom'
     _city(): string;            // 'New Ortiz chester'
@@ -178,7 +177,7 @@ declare module "casual" {
     rgb_array(): Array<number>        // [ 194, 193, 166 ]
   }
 
-  interface casual {
+  interface Casual {
     // EMBEDDED GENERATORS
     country: string;         // 'United Kingdom'
     city: string;            // 'New Ortiz chester'
@@ -231,7 +230,7 @@ declare module "casual" {
     phone: string;            // '982-790-2592'
 
     // numbers
-
+    boolean: boolean;
     random: number;                         // 0.7171590146608651 (core generator)
     integer(from?: number, to?: number): number  // 632
     double(from?: number, to?: number): number  // -234.12987444
@@ -280,7 +279,7 @@ declare module "casual" {
     rgb_array: Array<number>        // [ 194, 193, 166 ]
 
     // CUSTOM GENERATORS
-    define(type: string, cb: () => any): void;
+    define(type: string, cb: (...args: any[]) => any): void;
 
     // HELPERS
     random_element(elements: Array<any>): any;
@@ -297,7 +296,8 @@ declare module "casual" {
     // GENERATORS functions
     functions(): functions;
   }
-  
-  const casual: generators & casual;
+}
+declare module "casual" {
+  const casual: Casual.Generators & Casual.Casual;
   export = casual;
 }


### PR DESCRIPTION
[Issue #71](https://github.com/boo1ean/casual/issues/71)

Also i have extract interface into namespace instead of module so that i can override/extend interface on added generator by define.

After this commit I can extend interface by below example : 
`

declare namespace Casual {
  interface Casual {
    boolean: boolean;
    define(type: string, cb: (...args: any[]) => any): void;
  }
}
`