### PR TITLE
mongoObjectIdStr -> a valid ObjectId hex string

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,17 +124,18 @@ casual.card_data            // { type: 'MasterCard', number: '5307558778577046',
 
 // Misc
 
-casual.country_code    // 'ES'
-casual.language_code   // 'ru'
-casual.locale          // 'hi_IN'
-casual.currency        // { symbol: 'R', name: 'South African Rand', symbol_native: 'R', decimal_digits: 2, rounding: 0, code: 'ZAR', name_plural: 'South African rand' }		
-casual.currency_code   // 'TRY'
-casual.currency_symbol // 'TL'
-casual.currency_name   // Turkish Lira
-casual.mime_type       // 'audio/mpeg'
-casual.file_extension  // 'rtf'
-casual.boolean         // true
-casual.uuid            // '2f4dc6ba-bd25-4e66-b369-43a13e0cf150'
+casual.country_code     // 'ES'
+casual.language_code    // 'ru'
+casual.locale           // 'hi_IN'
+casual.currency         // { symbol: 'R', name: 'South African Rand', symbol_native: 'R', decimal_digits: 2, rounding: 0, code: 'ZAR', name_plural: 'South African rand' }
+casual.currency_code    // 'TRY'
+casual.currency_symbol  // 'TL'
+casual.currency_name    // Turkish Lira
+casual.mime_type        // 'audio/mpeg'
+casual.file_extension   // 'rtf'
+casual.boolean          // true
+casual.uuid             // '2f4dc6ba-bd25-4e66-b369-43a13e0cf150'
+casual.MongoObjectIdStr // '2a5d1ce1bab2530a76cd936ce'
 
 // Colors
 

--- a/src/providers/misc.js
+++ b/src/providers/misc.js
@@ -1483,7 +1483,7 @@ var provider = {
 		'video/x-msvideo': 'avi',
 		'video/x-sgi-movie': 'movie'
 	},
-	
+
 	animals: [
 		"alligator",
 		"alpaca",
@@ -1641,7 +1641,11 @@ var provider = {
 			return a ? (a ^ number.random() * 16 >> a / 4).toString(16) : ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, b);
 		}))();
 	},
-	
+
+	MongoObjectIdStr: function () {
+		return Array.from({length: 24}).map(() => Math.floor(number.random() * 16).toString(16)).join('')
+	},
+
 	animal: function () {
 		return this.random_element(this.animals);
 	}

--- a/test/casual.js
+++ b/test/casual.js
@@ -120,7 +120,8 @@ describe('API', function() {
 		'mime_type',
 		'file_extension',
 		'boolean',
-		'uuid'
+		'uuid',
+		'MongoObjectIdStr'
 	];
 
 	var color = [


### PR DESCRIPTION
I am using casual to generate seeded random data to be inserted in mongo, to do tests.

I need predictable ObjectId. I am using casual.random to create the ObjectId on my own but I reckon that it would be really nice to have this feature in casual.

So, Here is the pull request.  