### PR TITLE
Add array of (fixes #29)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -282,7 +282,7 @@ declare namespace Casual {
     define(type: string, cb: (...args: any[]) => any): void;
 
     // HELPERS
-    array_of<T>(x: number, gen: ()=>T): T;
+    array_of<T>(x: number, gen: ()=>T): T[];
     random_element<T>(elements: Array<T>): T;
     random_value<K extends string | number | symbol, V>(obj: { [key in K]: V }): V;
     random_key<K extends string | number | symbol, V>(obj: { [key in K]: V }): K;

--- a/index.d.ts
+++ b/index.d.ts
@@ -282,7 +282,7 @@ declare namespace Casual {
     define(type: string, cb: (...args: any[]) => any): void;
 
     // HELPERS
-    to_array<T>(x: number, gen: ()=>T): T;
+    array_of<T>(x: number, gen: ()=>T): T;
     random_element<T>(elements: Array<T>): T;
     random_value<K extends string | number | symbol, V>(obj: { [key in K]: V }): V;
     random_key<K extends string | number | symbol, V>(obj: { [key in K]: V }): K;

--- a/index.d.ts
+++ b/index.d.ts
@@ -282,6 +282,7 @@ declare namespace Casual {
     define(type: string, cb: (...args: any[]) => any): void;
 
     // HELPERS
+    to_array<T>(x: number, gen: ()=>T): T;
     random_element<T>(elements: Array<T>): T;
     random_value<K extends string | number | symbol, V>(obj: { [key in K]: V }): V;
     random_key<K extends string | number | symbol, V>(obj: { [key in K]: V }): K;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,16 @@
 var number = require('./providers/number');
 
+
+var array_of = function(times, generator) {
+	var result = [];
+
+	for (var i = 0; i < times; ++i) {
+		result.push(generator());
+	}
+
+	return result;
+};
+
 var random_element = function(array) {
 	var index = this.integer(0, array.length - 1);
 	return array[index];
@@ -71,6 +82,7 @@ var populate_one_of = function(formats) {
 };
 
 module.exports = {
+	array_of: array_of,
 	random_element: random_element,
 	random_value: random_value,
 	random_key: random_key,

--- a/test/casual.js
+++ b/test/casual.js
@@ -200,7 +200,7 @@ describe('API', function() {
 			});
 		});
 
-		describe.only('array_of', function() {
+		describe('array_of', function() {
 			it("Should generate an array of results", function(done) {
 				var array = ["test", "test", "test"];
 				var result = casual.array_of(3, function() {return "test"});

--- a/test/casual.js
+++ b/test/casual.js
@@ -200,6 +200,18 @@ describe('API', function() {
 			});
 		});
 
+		describe.only('array_of', function() {
+			it("Should generate an array of results", function(done) {
+				var array = ["test", "test", "test"];
+				var result = casual.array_of(3, function() {return "test"});
+
+				result.should.have.length(3);
+				result.should.containDeep(array);
+
+				return done();
+			});
+		});
+
 		describe('random_element', function() {
 			it('Should pick random element from array', function(done) {
 				var array = [1,2,3,4,5,23,6,7,8,95,43];


### PR DESCRIPTION
This PR includes tests and typescript description.

**Adds helper function `array_of`**

```js
var array_of = function(times, generator) {
	var result = [];

	for (var i = 0; i < times; ++i) {
		result.push(generator());
	}

	return result;
};
```

https://github.com/boo1ean/casual#generators-functions
Under the generated functions header in the Readme, this function is used as example, I thought it would be better to have this helper function availible in casual.

- [x]  Tested locally 